### PR TITLE
Fix restore_registry for Odoo < 15.0

### DIFF
--- a/odoo_test_helper/fake_model_loader.py
+++ b/odoo_test_helper/fake_model_loader.py
@@ -149,9 +149,11 @@ class FakeModelLoader(object):
 
         self._clean_module_to_model()
 
-        # reload is need to resetup correctly the field on the record
+        # reload is need to reset correctly the field on the record
         with mock.patch.object(self.env.cr, "commit"):
-            self.env.registry.model_cache.clear()
+            # Only before V15
+            if hasattr(self.env.registry, "model_cache"):
+                self.env.registry.model_cache.clear()
             model_names = self.env.registry.load(
                 self.env.cr, FakePackage(self._module_name)
             )


### PR DESCRIPTION
This commit https://github.com/OCA/OCB/commit/81ff2717cfba2395f233dd6fe9afd71bdab86ff0
removed `model_cache`.

Replaces #13 