### PR TITLE
[FIX] Import unittest.mock for python 3

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
 known_odoo=odoo
-known_third_party = mock,setuptools
+known_third_party = setuptools

--- a/odoo_test_helper/fake_model_loader.py
+++ b/odoo_test_helper/fake_model_loader.py
@@ -9,9 +9,13 @@
 
 import logging
 
-import mock
 from odoo import models
 from odoo.tools import OrderedSet
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 module_to_models = models.MetaModel.module_to_models
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
Python 3 includes mock upstream, and modern Odoo versions do not require downstream mock anymore.

Fix this import to avoid having to add an extra dependency.

@moduon MT-295