### PR TITLE
[FIX] restore_registry in Odoo 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,12 @@ jobs:
       python: 3.7
       env: VERSION="14.0"
     - stage: test
+      python: 3.8
+      env: VERSION="15.0"
+    - stage: test
+      python: 3.8
+      env: VERSION="16.0"
+    - stage: test
       python: 3.6
       env: VERSION="master"
   # TODO: test 3.8

--- a/tests/test_helper/tests/test_example.py
+++ b/tests/test_helper/tests/test_example.py
@@ -3,12 +3,18 @@
 # @author: Sébastien BEAU <sebastien.beau@akretion.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo.tests import SavepointCase
+from odoo.release import version_info
+
+if version_info[0] < 15:
+    from odoo.tests import SavepointCase as TransactionCase
+else:
+    # Odoo 15 and later: TransactionCase rolls back between tests
+    from odoo.tests import TransactionCase
 
 from odoo_test_helper import FakeModelLoader
 
 
-class TestMixin(SavepointCase):
+class TestMixin(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestMixin, cls).setUpClass()

--- a/tests/test_helper/tests/test_registry.py
+++ b/tests/test_helper/tests/test_registry.py
@@ -3,12 +3,18 @@
 # @author: Sébastien BEAU <sebastien.beau@akretion.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo.tests import SavepointCase
+from odoo.release import version_info
+
+if version_info[0] < 15:
+    from odoo.tests import SavepointCase as TransactionCase
+else:
+    # Odoo 15 and later: TransactionCase rolls back between tests
+    from odoo.tests import TransactionCase
 
 from odoo_test_helper import FakeModelLoader
 
 
-class TestMixin(SavepointCase):
+class TestMixin(TransactionCase):
     def test_update_and_restore(self):
         loader = FakeModelLoader(self.env, self.__module__)
         loader.backup_registry()


### PR DESCRIPTION
See https://github.com/odoo/odoo/commit/cd122933867c096f61fae945f11e842ea84d06b8

This new attribute is the source of truth for the base classes, and in setup_models (called further down in the modified code in this PR), the model's base classes are reset from it: https://github.com/odoo/odoo/blob/e1f06479a526c703ccabc441b1e194646206b966/odoo/models.py#L2728-L2730.

The test failure fixed by this PR can be inspected in https://app.travis-ci.com/github/OCA/odoo-test-helper/builds/258453331