### PR TITLE
[FIX] AttributeError in 15.0 and 16.0 when fields are removed

### DIFF
--- a/odoo_test_helper/fake_model_loader.py
+++ b/odoo_test_helper/fake_model_loader.py
@@ -145,11 +145,9 @@ class FakeModelLoader(object):
         for key in self._original_registry:
             ori = self._original_registry[key]
             model = self.env.registry[key]
-            if hasattr(model, "_BaseModel__base_classes"):
+            if hasattr(model, "_BaseModel__base_classes"):  # As of 15.0
                 model._BaseModel__base_classes = ori["base"]
-            else:
-                # Before V16
-                model.__bases__ = ori["base"]
+            model.__bases__ = ori["base"]
             model._inherit_children = ori["_inherit_children"]
             model._inherits_children = ori["_inherits_children"]
             for field in model._fields:

--- a/tests/test_helper/tests/models.py
+++ b/tests/test_helper/tests/models.py
@@ -10,6 +10,8 @@ class ResPartner(models.Model):
     _inherit = ["res.partner", "test.mixin"]
     _name = "res.partner"
 
+    extra2 = fields.Char()
+
 
 class ResPartnerExtra(models.Model):
     _name = "res.partner.extra"

--- a/tests/test_helper/tests/test_example.py
+++ b/tests/test_helper/tests/test_example.py
@@ -34,6 +34,9 @@ class TestMixin(TransactionCase):
         super(TestMixin, cls).tearDownClass()
 
     def test_create(self):
-        partner = self.env["res.partner"].create({"name": "BAR", "test_char": "youhou"})
+        partner = self.env["res.partner"].create(
+            {"name": "BAR", "test_char": "youhou", "extra2": "quod"}
+        )
         self.assertEqual(partner.name, "FOO-BAR")
         self.assertEqual(partner.test_char, "youhou")
+        self.assertEqual(partner.extra2, "quod")

--- a/tests/test_helper/tests/test_registry.py
+++ b/tests/test_helper/tests/test_registry.py
@@ -36,6 +36,7 @@ class TestMixin(TransactionCase):
         loader.backup_registry()
 
         self.assertNotIn("res.partner.extra", self.env.registry)
+        self.assertNotIn("extra2", self.env["res.partner"]._fields)
         self.assertNotIn("test_char", self.env["res.partner"]._fields)
 
         from .models import ResPartner
@@ -43,10 +44,12 @@ class TestMixin(TransactionCase):
         loader.update_registry([ResPartner])
 
         self.assertNotIn("res.partner.extra", self.env.registry)
+        self.assertIn("extra2", self.env["res.partner"]._fields)
         self.assertIn("test_char", self.env["res.partner"]._fields)
 
         loader.restore_registry()
         self.assertNotIn("res.partner.extra", self.env.registry)
+        self.assertNotIn("extra2", self.env["res.partner"]._fields)
         self.assertNotIn("test_char", self.env["res.partner"]._fields)
 
     def test_load_res_partner_extra(self):


### PR DESCRIPTION
Fixes a regression of https://github.com/OCA/odoo-test-helper/pull/22 when removing fields from the registry

```
ERROR openerp_test unittest.suite: ERROR: tearDownClass (odoo.addons.test_helper.tests.test_example.TestMixin)
Traceback (most recent call last):
File "/home/travis/build/OCA/odoo-test-helper/test_helper/tests/test_example.py", line 33, in tearDownClass
cls.loader.restore_registry()
File "/home/travis/build/OCA/odoo-test-helper/odoo_test_helper/fake_model_loader.py", line 158, in restore_registry
delattr(model, field)
AttributeError: extra2
```
