### PR TITLE
[FIX] Ensures registry is cleaned up in addons without models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ install:
   - travis_install_nightly
   - pip install -e .
   - mv tests/test_helper test_helper
+  - mv tests/test_helper_bis test_helper_bis
 
 script:
   - travis_run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
       python: 3.8
       install: pip install pre-commit twine
       script:
+        - pip install "urllib3>=1.25.7,<2"
         - pip wheel -w /tmp/build --no-deps .
         - twine check /tmp/build/*
       env: TESTS="0"

--- a/odoo_test_helper/fake_model_loader.py
+++ b/odoo_test_helper/fake_model_loader.py
@@ -112,6 +112,11 @@ class FakeModelLoader(object):
     def _clean_module_to_model(self):
         for key in self._original_module_to_models:
             module_to_models[key] = list(self._original_module_to_models[key])
+        for key in set(module_to_models.keys()).difference(
+            self._original_module_to_models.keys()
+        ):
+            # remove module that have been added during the test
+            del module_to_models[key]
 
     def update_registry(self, odoo_models):
         # Since V13 field are computed at the end

--- a/tests/test_helper_bis/__manifest__.py
+++ b/tests/test_helper_bis/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2023 ACSONE SA/NV (http://www.acsone.eu).
+
+{
+    "name": "Test Helper Bis",
+    "summary": "Fake module for testing. This module doesn't define any model,"
+    " only test models.",
+    "version": "0.0.0",
+    "category": "Uncategorized",
+    "author": " ACSONE SA/NV",
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {"python": [], "bin": []},
+    "depends": ["base"],
+    "data": [],
+    "demo": [],
+    "qweb": [],
+}

--- a/tests/test_helper_bis/tests/__init__.py
+++ b/tests/test_helper_bis/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_registry

--- a/tests/test_helper_bis/tests/models.py
+++ b/tests/test_helper_bis/tests/models.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Akretion (http://www.akretion.com).
+# @author: Sébastien BEAU <sebastien.beau@akretion.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = ["res.partner"]
+    _name = "res.partner"
+
+    extra2 = fields.Char()
+
+
+class ResPartnerExtra(models.Model):
+    _name = "res.partner.extra"
+    _description = "Res Partner Extra"
+
+    partner_id = fields.Many2one("res.partner", "Partner")
+    extra = fields.Char()

--- a/tests/test_helper_bis/tests/test_registry.py
+++ b/tests/test_helper_bis/tests/test_registry.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Akretion (http://www.akretion.com).
+# @author: Sébastien BEAU <sebastien.beau@akretion.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.release import version_info
+
+if version_info[0] < 15:
+    from odoo.tests import SavepointCase as TransactionCase
+else:
+    # Odoo 15 and later: TransactionCase rolls back between tests
+    from odoo.tests import TransactionCase
+
+from odoo_test_helper import FakeModelLoader
+
+
+class TestMixin(TransactionCase):
+    def test_update_and_restore(self):
+        """
+        Ensure that a test model defined into an addon without model
+        is correctly removed from the registry after the test.
+        """
+        loader = FakeModelLoader(self.env, self.__module__)
+        loader.backup_registry()
+        from .models import ResPartner, ResPartnerExtra
+
+        self.assertNotIn("res.partner.extra", self.env.registry)
+
+        loader.update_registry([ResPartner, ResPartnerExtra])
+        self.assertIn("res.partner.extra", self.env.registry)
+
+        loader.restore_registry()
+        self.assertNotIn("res.partner.extra", self.env.registry)
+
+    def test_load_res_partner(self):
+        """
+        Check that a model extended by a test model in an addon without models
+        is correctly reset after the test.
+        """
+        loader = FakeModelLoader(self.env, self.__module__)
+        loader.backup_registry()
+
+        self.assertIn("res.partner", self.env.registry)
+        self.assertNotIn("res.partner.extra", self.env.registry)
+        self.assertNotIn("extra2", self.env["res.partner"]._fields)
+
+        from .models import ResPartner
+
+        loader.update_registry([ResPartner])
+
+        self.assertNotIn("res.partner.extra", self.env.registry)
+        self.assertIn("extra2", self.env["res.partner"]._fields)
+
+        loader.restore_registry()
+        self.assertNotIn("res.partner.extra", self.env.registry)
+        self.assertNotIn("extra2", self.env["res.partner"]._fields)
+        self.assertIn("res.partner", self.env.registry)
+
+    def test_load_res_partner_extra(self):
+        loader = FakeModelLoader(self.env, self.__module__)
+        loader.backup_registry()
+
+        self.assertNotIn("res.partner.extra", self.env.registry)
+
+        from .models import ResPartnerExtra
+
+        loader.update_registry([ResPartnerExtra])
+
+        self.assertIn("res.partner.extra", self.env.registry)
+        self.assertNotIn("extra2", self.env["res.partner"]._fields)
+
+        loader.restore_registry()
+        self.assertNotIn("res.partner.extra", self.env.registry)


### PR DESCRIPTION
Before this change, if the helper was used in an addon that doesn't define models, test models was not removed from the registry aftet the call to the   method.