### PR TITLE
[FIX] FakeModelLoader: avoid loading module again on restore_registry() for version < 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,7 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - pip install -e .
-  - mv tests/test_helper test_helper
-  - mv tests/test_helper_bis test_helper_bis
+  - mv tests/test_helper* .
 
 script:
   - travis_run_tests

--- a/odoo_test_helper/fake_model_loader.py
+++ b/odoo_test_helper/fake_model_loader.py
@@ -177,15 +177,16 @@ class FakeModelLoader(object):
 
         self._clean_module_to_model()
 
-        # reload is need to reset correctly the field on the record
-        with mock.patch.object(self.env.cr, "commit"):
-            # Only before V15
-            if hasattr(self.env.registry, "model_cache"):
+        # reload is needed to reset correctly the field on the record
+        # but only up to Odoo 14
+        if version_info[0] < 15:
+
+            with mock.patch.object(self.env.cr, "commit"):
                 self.env.registry.model_cache.clear()
-            model_names = self.env.registry.load(
-                self.env.cr, FakePackage(self._module_name)
-            )
-            self.env.registry.setup_models(self.env.cr)
-            self.env.registry.init_models(
-                self.env.cr, model_names, {"module": self._module_name}
-            )
+                model_names = self.env.registry.load(
+                    self.env.cr, FakePackage(self._module_name)
+                )
+                self.env.registry.setup_models(self.env.cr)
+                self.env.registry.init_models(
+                    self.env.cr, model_names, {"module": self._module_name}
+                )

--- a/tests/test_helper_extended/__init__.py
+++ b/tests/test_helper_extended/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/test_helper_extended/__manifest__.py
+++ b/tests/test_helper_extended/__manifest__.py
@@ -1,0 +1,19 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+{
+    "name": "Test Helper Extended",
+    "summary": "Another fake module extending fake module Test Helper for testing",
+    "version": "0.0.0",
+    "category": "Uncategorized",
+    "website": "www.akretion.com",
+    "author": " Akretion",
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {"python": [], "bin": []},
+    "depends": ["test_helper"],
+    "data": [],
+    "demo": [],
+    "qweb": [],
+}

--- a/tests/test_helper_extended/models/__init__.py
+++ b/tests/test_helper_extended/models/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mixin

--- a/tests/test_helper_extended/models/test_mixin.py
+++ b/tests/test_helper_extended/models/test_mixin.py
@@ -1,0 +1,10 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class TestMixin(models.AbstractModel):
+    _inherit = "test.mixin"
+    _description = "Test Mixin Extension"
+
+    test_char_02 = fields.Char()

--- a/tests/test_helper_extended/tests/__init__.py
+++ b/tests/test_helper_extended/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_registry

--- a/tests/test_helper_extended/tests/test_registry.py
+++ b/tests/test_helper_extended/tests/test_registry.py
@@ -1,0 +1,33 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.release import version_info
+
+if version_info[0] >= 15:
+    from odoo.tests import TransactionCase
+
+    from odoo_test_helper import FakeModelLoader
+
+    class TestMixin(TransactionCase):
+        def test_mixin_after_reloading_parent_module(self):
+            self.assertIn("test.mixin", self.env.registry)
+            self.assertIn("test_char", self.env["test.mixin"]._fields)
+            self.assertIn("test_char_02", self.env["test.mixin"]._fields)
+
+            loader = FakeModelLoader(self.env, "odoo.addons.test_helper")
+            loader.backup_registry()
+
+            # trigger reload of parent module: test_helper
+            loader.update_registry(())
+
+            self.assertIn("test.mixin", self.env.registry)
+            self.assertIn("test_char", self.env["test.mixin"]._fields)
+            # new field should not be there anymore
+            self.assertNotIn("test_char_02", self.env["test.mixin"]._fields)
+
+            # but now we restore registry
+            loader.restore_registry()
+
+            self.assertIn("test.mixin", self.env.registry)
+            self.assertIn("test_char", self.env["test.mixin"]._fields)
+            # new field should be there again
+            self.assertIn("test_char_02", self.env["test.mixin"]._fields)


### PR DESCRIPTION
- FakeModelLoader currently [loads the current module](https://github.com/OCA/odoo-test-helper/blob/9ccb57d7749605b9bb61e27f882c5959ef058b9f/odoo_test_helper/fake_model_loader.py#L180) on `restore_registry()`
- Comment says "# reload is need to reset correctly the field on the record": based on some tests, this was indeed needed for Odoo up to 14.0
- However, it creates trouble in `post_install` tests, see cases:
  - [here](https://github.com/OCA/edi-framework/pull/20)
  - [here](https://github.com/OCA/edi-framework/pull/19)
  - [here](https://github.com/OCA/edi-framework/pull/26)
- So this PR:
  - changes the behavior of `reload_registry()` to avoid loading the module again for Odoo 15.0+
  - introduces a test case for odoo 15.0+ to make expectations explicit [here](https://github.com/OCA/odoo-test-helper/blob/79b6fe7d74dcad1b0c57af148d3a71e2987da752/tests/test_helper_extended/tests/test_registry.py)
- This will allow to remove the hacky workarounds from the PRs above
- While not breaking anything for older versions