### PR TITLE
[DONOTMERGE] PR to demonstrate an issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,12 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
       - uses: pre-commit/action@v2.0.0
   deploy:
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,8 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - pip install -e .
-  - mv tests/test_helper* .
+  # move test addons from tests/ to .
+  - find tests/ -mindepth 1 -maxdepth 1 -type d ! -name 'script' -exec mv {} . \;
 
 script:
   - travis_run_tests

--- a/tests/edi_account_oca/__init__.py
+++ b/tests/edi_account_oca/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/edi_account_oca/__manifest__.py
+++ b/tests/edi_account_oca/__manifest__.py
@@ -1,0 +1,17 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+{
+    "name": "Test EDI",
+    "summary": "Another fake module to try to reproduce an issue with EDI modules",
+    "version": "0.0.0",
+    "category": "Uncategorized",
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {"python": [], "bin": []},
+    "depends": ["account", "edi_oca"],
+    "data": [],
+    "demo": [],
+    "qweb": [],
+}

--- a/tests/edi_account_oca/models/__init__.py
+++ b/tests/edi_account_oca/models/__init__.py
@@ -1,0 +1,1 @@
+from . import edi

--- a/tests/edi_account_oca/models/edi.py
+++ b/tests/edi_account_oca/models/edi.py
@@ -1,0 +1,13 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _name = "account.move"
+    _inherit = ["account.move", "edi.exchange.consumer.mixin"]
+
+    edi_disable_auto = fields.Boolean(
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )

--- a/tests/edi_endpoint_oca/__init__.py
+++ b/tests/edi_endpoint_oca/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/edi_endpoint_oca/__manifest__.py
+++ b/tests/edi_endpoint_oca/__manifest__.py
@@ -1,0 +1,17 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+{
+    "name": "Test EDI",
+    "summary": "Another fake module to try to reproduce an issue with EDI modules",
+    "version": "0.0.0",
+    "category": "Uncategorized",
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {"python": [], "bin": []},
+    "depends": ["edi_oca"],
+    "data": [],
+    "demo": [],
+    "qweb": [],
+}

--- a/tests/edi_endpoint_oca/models/__init__.py
+++ b/tests/edi_endpoint_oca/models/__init__.py
@@ -1,0 +1,1 @@
+from . import edi

--- a/tests/edi_endpoint_oca/models/edi.py
+++ b/tests/edi_endpoint_oca/models/edi.py
@@ -1,0 +1,31 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class EDIExchangeRecord(models.Model):
+    _inherit = "edi.exchange.record"
+
+    edi_endpoint_id = fields.Many2one(
+        comodel_name="edi.endpoint",
+        readonly=True,
+        string="Endpoint",
+        help="Record generated via this endpoint",
+    )
+
+
+class EDIEndpoint(models.Model):
+    _name = "edi.endpoint"
+
+
+class EDIExchangeConsumerMixin(models.AbstractModel):
+    _inherit = "edi.exchange.consumer.mixin"
+
+    origin_edi_endpoint_id = fields.Many2one(
+        string="EDI origin endpoint",
+        comodel_name="edi.endpoint",
+        ondelete="set null",
+        related="origin_exchange_record_id.edi_endpoint_id",
+        # Store it to ease searching
+        store=True,
+    )

--- a/tests/edi_oca/__init__.py
+++ b/tests/edi_oca/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/tests/edi_oca/__manifest__.py
+++ b/tests/edi_oca/__manifest__.py
@@ -1,0 +1,17 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+{
+    "name": "Test EDI",
+    "summary": "Another fake module to try to reproduce an issue with EDI modules",
+    "version": "0.0.0",
+    "category": "Uncategorized",
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {"python": [], "bin": []},
+    "depends": [],
+    "data": [],
+    "demo": [],
+    "qweb": [],
+}

--- a/tests/edi_oca/models/__init__.py
+++ b/tests/edi_oca/models/__init__.py
@@ -1,0 +1,1 @@
+from . import edi

--- a/tests/edi_oca/models/edi.py
+++ b/tests/edi_oca/models/edi.py
@@ -1,0 +1,18 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class EDIExchangeRecord(models.Model):
+    _name = "edi.exchange.record"
+
+
+class EDIExchangeConsumerMixin(models.AbstractModel):
+    _name = "edi.exchange.consumer.mixin"
+
+    origin_exchange_record_id = fields.Many2one(
+        string="EDI origin record",
+        comodel_name="edi.exchange.record",
+        ondelete="set null",
+        help="EDI record that originated this document.",
+    )

--- a/tests/edi_oca/tests/__init__.py
+++ b/tests/edi_oca/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_registry

--- a/tests/edi_oca/tests/fake_models.py
+++ b/tests/edi_oca/tests/fake_models.py
@@ -1,0 +1,14 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class EdiExchangeConsumerTest(models.Model):
+    _name = "edi.exchange.consumer.test"
+    _inherit = ["edi.exchange.consumer.mixin"]
+    _description = "Model used only for test"
+
+    name = fields.Char()
+
+    def _get_edi_exchange_record_name(self, exchange_record):
+        return self.id

--- a/tests/edi_oca/tests/test_registry.py
+++ b/tests/edi_oca/tests/test_registry.py
@@ -1,0 +1,23 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.release import version_info
+from odoo.tests.common import tagged
+
+if version_info[0] < 15:
+    from odoo.tests import SavepointCase as TransactionCase
+else:
+    # Odoo 15 and later: TransactionCase rolls back between tests
+    from odoo.tests import TransactionCase
+
+from odoo_test_helper import FakeModelLoader
+
+
+@tagged("-at_install", "post_install")
+class TestEdi(TransactionCase):
+    def test_edi(self):
+        loader = FakeModelLoader(self.env, "odoo.addons.edi_oca")
+        loader.backup_registry()
+
+        from .fake_models import EdiExchangeConsumerTest
+
+        loader.update_registry((EdiExchangeConsumerTest,))


### PR DESCRIPTION
This PR demonstrates an issue that can happen when:
- FakeModelLoader is used in a `post_install` test;
- the tested module has modules that depend on it.

Here concretely we have:
- `edi_oca`:
  - edi.exchange.record (Model)
  - edi.exchange.consumer.mixin (AbstractModel)
- `edi_endpoint_oca` (depends on `edi_oca`)
  - edi.exchange.record.edi_endpoint_id
- `edi_account_oca` (depends on `edi_oca`)
  - `account.move.original_edi_endpoint_id` -> `edi.exchange.consumer.mixin.origin_exchange_record_id.edi_endpoint_id`

The exception:

```
ERROR: TestEdi.test_edi
Traceback (most recent call last):
  File "/home/travis/build/OCA/odoo-test-helper/edi_oca/tests/test_registry.py", line 23, in test_edi
    loader.update_registry((EdiExchangeConsumerTest,))
  File "/home/travis/build/OCA/odoo-test-helper/odoo_test_helper/fake_model_loader.py", line 150, in update_registry
    self.env.registry.setup_models(self.env.cr)
  File "<decorator-gen-19>", line 2, in setup_models
  File "/home/travis/odoo-16.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/travis/odoo-16.0/odoo/modules/registry.py", line 298, in setup_models
    model._setup_fields()
  File "/home/travis/odoo-16.0/odoo/models.py", line 2813, in _setup_fields
    field.setup(self)
  File "/home/travis/odoo-16.0/odoo/fields.py", line 536, in setup
    self.setup_related(model)
  File "/home/travis/odoo-16.0/odoo/fields.py", line 601, in setup_related
    raise KeyError(
KeyError: 'Field edi_endpoint_id referenced in related field definition account.move.origin_edi_endpoint_id does not exist.'
```

Explanation:
- on [`registry.load()`](https://github.com/odoo/odoo/blob/16.0/odoo/modules/registry.py#L223), models cache is [clear](https://github.com/odoo/odoo/blob/557a1a73fe3c7539da1c27ee5abc1e701a2fca43/odoo/modules/registry.py#L236);
- then only `edi_oca` is loaded, not the modules that depend on it;
- so the field added by `edi_endpoint_oca` (`edi_endpoint_id` on `edi.exchange.record`), is not in registry anymore

Takeaways:
- it is fine to use FakeModelLoader in an `at_install` test (aka "unit" test)
- but NOT in a `post_install` test (aka "integration" test)
