### PR TITLE
[FIX] pre-commit: use ubuntu-22.04 / python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,12 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
       - uses: pre-commit/action@v2.0.0
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
to align with other oca addons repos, see:
https://github.com/OCA/oca-addons-repo-template/blob/master/src/.github/workflows/pre-commit.yml.jinja