### PR TITLE
[FIX] CI: Publish cannot have needs inside it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Publish to PyPI
 
 on:
   pull_request:
@@ -15,9 +15,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    needs:
-      - pre-commit
-      # - tests TODO
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Otherwise, publish fails
https://github.com/OCA/odoo-test-helper/actions/runs/22219043109