### PR TITLE
[FIX] Compatibility with odoo 19

### DIFF
--- a/odoo_test_helper/fake_model_loader.py
+++ b/odoo_test_helper/fake_model_loader.py
@@ -31,7 +31,12 @@ except ImportError:
 
 from .whitelist import WHITELIST
 
-module_to_models = models.MetaModel.module_to_models
+module_to_models = getattr(
+    models.MetaModel,
+    "module_to_models",
+    models.MetaModel._module_to_models__,
+)
+
 _logger = logging.getLogger(__name__)
 
 
@@ -155,10 +160,14 @@ class FakeModelLoader(object):
                 module_to_models[self._module_name].append(model)
 
         with mock.patch.object(self.env.cr, "commit"):
-            model_names = self.env.registry.load(
-                self.env.cr, FakePackage(self._module_name)
-            )
-            self.env.registry.setup_models(self.env.cr)
+            if hasattr(self.env.registry, "setup_models"):  # Odoo < 19
+                model_names = self.env.registry.load(
+                    self.env.cr, FakePackage(self._module_name)
+                )
+                self.env.registry.setup_models(self.env.cr)
+            else:  # Odoo >= 19
+                model_names = self.env.registry.load(FakePackage(self._module_name))
+                self.env.registry._setup_models__(self.env.cr, [])
             self.env.registry.init_models(
                 self.env.cr, model_names, {"module": self._module_name}
             )


### PR DESCRIPTION
 Closes #45

- Fix `setup_models` renamed to `_setup_models__(cr, [])` in 19
- Fix `Registry.load()` call for Odoo 19: signature is `load(module)` instead of `load(cr, package)`

