### PR TITLE
[19.0] FakeModelLoader: complete Odoo 19.0 support (supersedes #38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
             name: test with OCB 17.0
           - container: ghcr.io/oca/oca-ci/py3.10-ocb18.0:latest
             name: test with OCB 18.0
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb19.0:latest
+            name: test with OCB 19.0
     services:
       postgres:
         image: postgres:12.0
@@ -42,8 +44,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          # setuptools_scm derives the version from git tags.
+          fetch-depth: 0
       - name: Install odoo-test-helper
-        run: pip install .
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          pip install .
       - name: Install addons and dependencies
         run: oca_install_addons
       - name: Initialize test db

--- a/odoo_test_helper/fake_model_loader.py
+++ b/odoo_test_helper/fake_model_loader.py
@@ -31,7 +31,10 @@ except ImportError:
 
 from .whitelist import WHITELIST
 
-module_to_models = models.MetaModel.module_to_models
+try:
+    module_to_models = models.MetaModel.module_to_models
+except AttributeError:
+    module_to_models = models.MetaModel._module_to_models__
 _logger = logging.getLogger(__name__)
 
 
@@ -155,10 +158,16 @@ class FakeModelLoader(object):
                 module_to_models[self._module_name].append(model)
 
         with mock.patch.object(self.env.cr, "commit"):
-            model_names = self.env.registry.load(
-                self.env.cr, FakePackage(self._module_name)
-            )
-            self.env.registry.setup_models(self.env.cr)
+            try:
+                model_names = self.env.registry.load(
+                    self.env.cr, FakePackage(self._module_name)
+                )
+            except TypeError:
+                model_names = self.env.registry.load(FakePackage(self._module_name))
+            try:
+                self.env.registry.setup_models(self.env.cr)
+            except AttributeError:
+                self.env.registry._setup_models__(self.env.cr)
             self.env.registry.init_models(
                 self.env.cr, model_names, {"module": self._module_name}
             )

--- a/odoo_test_helper/fake_model_loader.py
+++ b/odoo_test_helper/fake_model_loader.py
@@ -34,8 +34,12 @@ from .whitelist import WHITELIST
 try:
     module_to_models = models.MetaModel.module_to_models
 except AttributeError:
+    # Odoo 19.0+ renamed the MetaModel registry of per-module model defs.
     module_to_models = models.MetaModel._module_to_models__
+
 _logger = logging.getLogger(__name__)
+
+ODOO_VERSION = version_info[0]
 
 
 class FakePackage(object):  # noqa
@@ -55,15 +59,11 @@ class FakeModelLoader(object):
             super().setUpClass()
             cls.loader = FakeModelLoader(cls.env, cls.__module__)
             cls.loader.backup_registry()
+            cls.addClassCleanup(cls.loader.restore_registry)
             from .fake_models import MyFakeModelClass1, MyFakeModelClass2
             cls.loader.update_registry(
                 (MyFakeModelClass1, MyFakeModelClass2)
             )
-
-        @classmethod
-        def tearDownClass(cls):
-            cls.loader.restore_registry()
-            super().tearDownClass()
 
     Usage on TransactionCase / HttpCase:
 
@@ -73,14 +73,11 @@ class FakeModelLoader(object):
             super().setUp()
             self.loader = FakeModelLoader(self.env, self.__module__)
             self.loader.backup_registry()
+            self.addCleanup(self.loader.restore_registry)
             from .fake_models import MyFakeModelClass1, MyFakeModelClass2
             self.loader.update_registry(
                 (MyFakeModelClass1, MyFakeModelClass2)
             )
-
-        def tearDown(self):
-            self.loader.restore_registry()
-            super().tearDown()
     """
 
     _original_registry = None
@@ -109,17 +106,30 @@ class FakeModelLoader(object):
                         "import test class".format(module, model)
                     )
 
+    def _backup_model(self, model):
+        if ODOO_VERSION >= 19:
+            # 19.0 reworked model build: the per-registry base classes live in
+            # ``_base_classes__`` (was ``__bases__`` / ``_BaseModel__base_classes``),
+            # and ``_inherit_children`` is a plain ``OrderedSet`` of names.
+            return {
+                "base": model._base_classes__,
+                "_fields": dict(model._fields),
+                "_inherit_children": OrderedSet(model._inherit_children),
+                "_inherits_children": set(model._inherits_children),
+            }
+        return {
+            "base": model.__bases__,
+            "_fields": model._fields.copy(),
+            "_inherit_children": OrderedSet(model._inherit_children._map.keys()),
+            "_inherits_children": set(model._inherits_children),
+        }
+
     def backup_registry(self):
         self._check_wrong_import()
         self._original_registry = {}
         self._original_module_to_models = {}
         for model_name, model in self.env.registry.models.items():
-            self._original_registry[model_name] = {
-                "base": model.__bases__,
-                "_fields": model._fields.copy(),
-                "_inherit_children": OrderedSet(model._inherit_children._map.keys()),
-                "_inherits_children": set(model._inherits_children),
-            }
+            self._original_registry[model_name] = self._backup_model(model)
         for key in module_to_models:
             self._original_module_to_models[key] = list(module_to_models[key])
 
@@ -132,11 +142,10 @@ class FakeModelLoader(object):
             # remove module that have been added during the test
             del module_to_models[key]
 
-    def update_registry(self, odoo_models):
-        # Since V13 field are computed at the end
-        # In the setup of your test if you create or modify a record that
-        # need to be recomputed we need to recompute them before reloading
-        # the registry
+    def _flush_before_reload(self):
+        # Since V13 fields are computed at the end. In the setup of your test
+        # if you create or modify a record that needs to be recomputed we need
+        # to recompute them before reloading the registry.
         if hasattr(self.env, "flush_all"):  # Odoo 16 and later
             self.env.flush_all()
         elif hasattr(self.env.all, "tocompute"):
@@ -145,6 +154,9 @@ class FakeModelLoader(object):
                 to_recompute_models.add(field.model_name)
             for model in to_recompute_models:
                 self.env[model].recompute()
+
+    def update_registry(self, odoo_models):
+        self._flush_before_reload()
 
         # In case that you are re-using fake model from an other module
         # Odoo have already modify the module_to_models variable
@@ -158,21 +170,49 @@ class FakeModelLoader(object):
                 module_to_models[self._module_name].append(model)
 
         with mock.patch.object(self.env.cr, "commit"):
-            try:
+            if ODOO_VERSION >= 19:
+                # 19.0: Registry.load takes a single module arg and only reads
+                # ``.name``; setup_models was renamed to ``_setup_models__``.
+                model_names = self.env.registry.load(FakePackage(self._module_name))
+                self.env.registry._setup_models__(self.env.cr)
+            else:
                 model_names = self.env.registry.load(
                     self.env.cr, FakePackage(self._module_name)
                 )
-            except TypeError:
-                model_names = self.env.registry.load(FakePackage(self._module_name))
-            try:
                 self.env.registry.setup_models(self.env.cr)
-            except AttributeError:
-                self.env.registry._setup_models__(self.env.cr)
             self.env.registry.init_models(
                 self.env.cr, model_names, {"module": self._module_name}
             )
 
+    def _restore_registry_19(self):
+        registry = self.env.registry
+        # Restore the inheritance structure of the original models so that a
+        # full re-setup rebuilds their fields without the fake extensions.
+        for name, ori in self._original_registry.items():
+            if name not in registry.models:
+                continue
+            model = registry[name]
+            model._base_classes__ = ori["base"]
+            model._inherit_children = ori["_inherit_children"]
+            model._inherits_children = ori["_inherits_children"]
+        # Drop the fake models created during the test. ``del registry[name]``
+        # also discards the name from every model's ``_inherit_children``.
+        for name in list(registry.models):
+            if name not in self._original_registry:
+                del registry[name]
+        self._clean_module_to_model()
+        # Force a full re-setup so ``__bases__`` and ``_fields__`` are rebuilt
+        # from the restored ``_base_classes__``.
+        for model in registry.models.values():
+            model._setup_done__ = False
+        with mock.patch.object(self.env.cr, "commit"):
+            registry._setup_models__(self.env.cr)
+
     def restore_registry(self):
+        if ODOO_VERSION >= 19:
+            self._restore_registry_19()
+            return
+
         for key in self._original_registry:
             ori = self._original_registry[key]
             model = self.env.registry[key]

--- a/test_addons/test_helper/models/test_mixin.py
+++ b/test_addons/test_helper/models/test_mixin.py
@@ -12,7 +12,8 @@ class TestMixin(models.AbstractModel):
 
     test_char = fields.Char()
 
-    @api.model
-    def create(self, vals):
-        vals["name"] = "FOO-{}".format(vals["name"])
-        return super(TestMixin, self).create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals["name"] = "FOO-{}".format(vals["name"])
+        return super().create(vals_list)


### PR DESCRIPTION
Completes Odoo 19.0 support for `FakeModelLoader`, on top of weinni2000's #38 (kept as the first commit).

#38 renamed the import-time symbols but left `backup_registry`/`restore_registry` on 18.0 internals with no 19.0 CI job, so it couldn't go green. This finishes the registry rework for 19.0 (`_base_classes__`, `_setup_models__`, `del registry[name]` + full re-setup on restore), adds **OCB 19.0 to the matrix**, and fixes the `setuptools_scm` wheel build (`safe.directory`, same as #49).

`FakeModelLoader` is imported in 88 files across ~24 OCA repos, so this unblocks their 19.0 test suites. Green on OCB 15–19.

Supersedes #38; folds in #49. Touches `fake_model_loader.py`/`test_mixin.py` also under #43 and #44 (florentx) — our changes are additive (19.0 branch + docstring uses their `addClassCleanup` pattern); happy to rebase after either lands.
